### PR TITLE
Properly handle datetime fields

### DIFF
--- a/mapogr.cpp
+++ b/mapogr.cpp
@@ -595,10 +595,38 @@ static char **msOGRGetValues(layerObj *layer, OGRFeatureH hFeature)
 
   int *itemindexes = (int*)layer->iteminfo;
 
+  int nYear;
+  int nMonth;
+  int nDay;
+  int nHour;
+  int nMinute;
+  int nSecond;
+  int nTZFlag;
+
   for(i=0; i<layer->numitems; i++) {
     if (itemindexes[i] >= 0) {
       // Extract regular attributes
-      values[i] = msStrdup(OGR_F_GetFieldAsString( hFeature, itemindexes[i]));
+      OGRFieldDefnH hFieldDefnRef = OGR_F_GetFieldDefnRef(hFeature, itemindexes[i]);
+      switch(OGR_Fld_GetType(hFieldDefnRef)) {
+      case OFTTime:
+      case OFTDate:
+      case OFTDateTime:
+          OGR_F_GetFieldAsDateTime(hFeature, itemindexes[i], &nYear, &nMonth, &nDay, &nHour, &nMinute, &nSecond, &nTZFlag);
+          switch(nTZFlag) {
+          case 0:
+          case 1:
+            values[i] = msStrdup(CPLSPrintf("%04d-%02d-%02dT%02d:%02d:%02d", nYear, nMonth, nDay, nHour, nMinute, nSecond));
+            break;
+          case 100:
+            values[i] = msStrdup(CPLSPrintf("%04d-%02d-%02dT%02d:%02d:%02dZ", nYear, nMonth, nDay, nHour, nMinute, nSecond));
+            break;
+          default:
+            values[i] = msStrdup(CPLSPrintf("%04d-%02d-%02dT%02d:%02d:%02d%+02d:00", nYear, nMonth, nDay, nHour, nMinute, nSecond, nTZFlag));
+          }
+          break;
+      default:
+        values[i] = msStrdup(OGR_F_GetFieldAsString(hFeature, itemindexes[i]));
+      }
     } else if (itemindexes[i] == MSOGR_FID_INDEX ) {
       values[i] = msStrdup(CPLSPrintf(CPL_FRMT_GIB,
                                       (GIntBig) OGR_F_GetFID(hFeature)));


### PR DESCRIPTION
# Omschrijving

De OGR backend van MapServer behandeld alle attributen (waaronder datum tijd velden) als string en laat het converteren naar string helemaal over aan OGR. In de code waarmee MapServer GML maakt worden echter aannames gedaan over de formatering van datum en tijd velden. Deze aanname klopt echter niet in ons geval. De OGR backend levert (in ieder geval bij gpkg) datums op in yyyy/mm/dd (of misschien wel yyyy/dd/mm?) formaat waar de GML-wegschrijfcode ISO formaat verwacht. 

https://dev.kadaster.nl/jira/browse/PDOK-13572

## Type verandering

- Bugfix

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [x] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [ ] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)