### PR TITLE
Fix datetime backport v2

### DIFF
--- a/mapgml.c
+++ b/mapgml.c
@@ -1051,10 +1051,26 @@ static void msGMLWriteItem(FILE *stream, gmlItemObj *item,
                        tm.tm_hour, tm.tm_min, tm.tm_sec,
                        pszEndTag);
           else
-              snprintf(encoded_value, 256, "%s%04d-%02d-%02dT%02d:%02d:%02dZ%s",
-                       pszStartTag,
-                       tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
-                       tm.tm_hour, tm.tm_min, tm.tm_sec, pszEndTag);
+          {
+              // Detected date time already formatted as YYYY-MM-DDTHH:mm:SS+ab:cd
+              // because msParseTime() can't handle time zones.
+              if( strlen(value) == 4+1+2+1+2+1+2+1+2+1+2+1+2+1+2 &&
+                  value[4] == '-' && value[7] == '-' && value[10] == 'T' &&
+                  value[13] == ':' && value[16] == ':' &&
+                  (value[19] == '+' || value[19] == '-') &&
+                  value[22] == ':' )
+              {
+                  snprintf(encoded_value, 256, "%s%s%s",
+                           pszStartTag, value, pszEndTag);
+              }
+              else
+              {
+                  snprintf(encoded_value, 256, "%s%04d-%02d-%02dT%02d:%02d:%02dZ%s",
+                           pszStartTag,
+                           tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+                           tm.tm_hour, tm.tm_min, tm.tm_sec, pszEndTag);
+              }
+          }
       }
   }
 

--- a/mapogr.cpp
+++ b/mapogr.cpp
@@ -595,10 +595,73 @@ static char **msOGRGetValues(layerObj *layer, OGRFeatureH hFeature)
 
   int *itemindexes = (int*)layer->iteminfo;
 
+  int nYear;
+  int nMonth;
+  int nDay;
+  int nHour;
+  int nMinute;
+  int nSecond;
+  int nTZFlag;
+
   for(i=0; i<layer->numitems; i++) {
     if (itemindexes[i] >= 0) {
       // Extract regular attributes
-      values[i] = msStrdup(OGR_F_GetFieldAsString( hFeature, itemindexes[i]));
+      const char* pszValue = OGR_F_GetFieldAsString(hFeature, itemindexes[i]);
+      if( pszValue[0] == 0 )
+      {
+          values[i] = msStrdup("");
+      }
+      else
+      {
+          OGRFieldDefnH hFieldDefnRef = OGR_F_GetFieldDefnRef(hFeature, itemindexes[i]);
+          switch(OGR_Fld_GetType(hFieldDefnRef)) {
+          case OFTTime:
+              OGR_F_GetFieldAsDateTime(hFeature, itemindexes[i], &nYear, &nMonth, &nDay, &nHour, &nMinute, &nSecond, &nTZFlag);
+              switch(nTZFlag) {
+              case 0: // Unknown time zone
+              case 1: // Local time zone (not specified)
+                values[i] = msStrdup(CPLSPrintf("%02d:%02d:%02d", nHour, nMinute, nSecond));
+                break;
+              case 100: // GMT
+                values[i] = msStrdup(CPLSPrintf("%02d:%02d:%02dZ", nHour, nMinute, nSecond));
+                break;
+              default: // Offset (in quarter-hour units) from GMT
+                const int TZOffset = std::abs(nTZFlag - 100) * 15;
+                const int TZHour = TZOffset / 60;
+                const int TZMinute = TZOffset % 60;
+                const char TZSign = (nTZFlag > 100) ? '+' : '-';
+                values[i] = msStrdup(CPLSPrintf("%02d:%02d:%02d%c%02d:%02d", nHour, nMinute,
+                  nSecond, TZSign, TZHour, TZMinute));
+              }
+              break;
+          case OFTDate:
+              OGR_F_GetFieldAsDateTime(hFeature, itemindexes[i], &nYear, &nMonth, &nDay, &nHour, &nMinute, &nSecond, &nTZFlag);
+              values[i] = msStrdup(CPLSPrintf("%04d-%02d-%02d", nYear, nMonth, nDay));
+              break;
+          case OFTDateTime:
+              OGR_F_GetFieldAsDateTime(hFeature, itemindexes[i], &nYear, &nMonth, &nDay, &nHour, &nMinute, &nSecond, &nTZFlag);
+              switch(nTZFlag) {
+              case 0: // Unknown time zone
+              case 1: // Local time zone (not specified)
+                values[i] = msStrdup(CPLSPrintf("%04d-%02d-%02dT%02d:%02d:%02d", nYear, nMonth, nDay, nHour, nMinute, nSecond));
+                break;
+              case 100: // GMT
+                values[i] = msStrdup(CPLSPrintf("%04d-%02d-%02dT%02d:%02d:%02dZ", nYear, nMonth, nDay, nHour, nMinute, nSecond));
+                break;
+              default: // Offset (in quarter-hour units) from GMT
+                const int TZOffset = std::abs(nTZFlag - 100) * 15;
+                const int TZHour = TZOffset / 60;
+                const int TZMinute = TZOffset % 60;
+                const char TZSign = (nTZFlag > 100) ? '+' : '-';
+                values[i] = msStrdup(CPLSPrintf("%04d-%02d-%02dT%02d:%02d:%02d%c%02d:%02d", nYear, nMonth, nDay, nHour, nMinute,
+                  nSecond, TZSign, TZHour, TZMinute));
+              }
+              break;
+          default:
+              values[i] = msStrdup(pszValue);
+              break;
+          }
+      }
     } else if (itemindexes[i] == MSOGR_FID_INDEX ) {
       values[i] = msStrdup(CPLSPrintf(CPL_FRMT_GIB,
                                       (GIntBig) OGR_F_GetFID(hFeature)));

--- a/mapogr.cpp
+++ b/mapogr.cpp
@@ -595,38 +595,10 @@ static char **msOGRGetValues(layerObj *layer, OGRFeatureH hFeature)
 
   int *itemindexes = (int*)layer->iteminfo;
 
-  int nYear;
-  int nMonth;
-  int nDay;
-  int nHour;
-  int nMinute;
-  int nSecond;
-  int nTZFlag;
-
   for(i=0; i<layer->numitems; i++) {
     if (itemindexes[i] >= 0) {
       // Extract regular attributes
-      OGRFieldDefnH hFieldDefnRef = OGR_F_GetFieldDefnRef(hFeature, itemindexes[i]);
-      switch(OGR_Fld_GetType(hFieldDefnRef)) {
-      case OFTTime:
-      case OFTDate:
-      case OFTDateTime:
-          OGR_F_GetFieldAsDateTime(hFeature, itemindexes[i], &nYear, &nMonth, &nDay, &nHour, &nMinute, &nSecond, &nTZFlag);
-          switch(nTZFlag) {
-          case 0:
-          case 1:
-            values[i] = msStrdup(CPLSPrintf("%04d-%02d-%02dT%02d:%02d:%02d", nYear, nMonth, nDay, nHour, nMinute, nSecond));
-            break;
-          case 100:
-            values[i] = msStrdup(CPLSPrintf("%04d-%02d-%02dT%02d:%02d:%02dZ", nYear, nMonth, nDay, nHour, nMinute, nSecond));
-            break;
-          default:
-            values[i] = msStrdup(CPLSPrintf("%04d-%02d-%02dT%02d:%02d:%02d%+02d:00", nYear, nMonth, nDay, nHour, nMinute, nSecond, nTZFlag));
-          }
-          break;
-      default:
-        values[i] = msStrdup(OGR_F_GetFieldAsString(hFeature, itemindexes[i]));
-      }
+      values[i] = msStrdup(OGR_F_GetFieldAsString( hFeature, itemindexes[i]));
     } else if (itemindexes[i] == MSOGR_FID_INDEX ) {
       values[i] = msStrdup(CPLSPrintf(CPL_FRMT_GIB,
                                       (GIntBig) OGR_F_GetFID(hFeature)));


### PR DESCRIPTION
# Omschrijving

Nieuwe backport van https://github.com/MapServer/MapServer/pull/6434 voor onze eigen 7.6 branch met daarin een aangescherpte fix voor het datum/tijd issue in de WFS.

Wijzigingen tov eerdere versie (https://github.com/PDOK/mapserver/pull/6)
- bugfix afhandeling tijdzones
- correct afhandelen ontbrekende (= NULL) attribuutwaarden: op dit moment bevatten lege datum/tijd attributen de waarde van een vorig datum/tijd attribuut.

https://dev.kadaster.nl/jira/browse/PDOK-13687

## Type verandering

- Bugfix

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [ ] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)